### PR TITLE
Update dev dependencies

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -10,10 +10,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - 7.1
-          - 7.2
-          - 7.3
-          - 7.4
           - 8.0
           - 8.1
 

--- a/composer.json
+++ b/composer.json
@@ -37,5 +37,10 @@
 			"@phpstan",
 			"@tester"
 		]
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"require": {
-		"php": "^7.1 || ^8.0"
+		"php": "^8.0"
 	},
 	"require-dev": {
 		"php-parallel-lint/php-parallel-lint": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,11 @@
 		"php": "^8.0"
 	},
 	"require-dev": {
-		"php-parallel-lint/php-parallel-lint": "^1.2",
-		"php-parallel-lint/php-console-highlighter": "^0.5.0",
-		"phpstan/phpstan": "^1.3",
-		"spaze/coding-standard": "^0.0",
-		"nette/tester": "^2.3"
+		"php-parallel-lint/php-parallel-lint": "^1.3",
+		"php-parallel-lint/php-console-highlighter": "^1.0",
+		"phpstan/phpstan": "^1.9",
+		"spaze/coding-standard": "^1.3",
+		"nette/tester": "^2.4"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
Requires PHP 8.0 or newer (for no real reason, mostly because dependencies require 7.2 so I had to bump the requirement anyway)