### PR TITLE
Support pure numerical session ids in sanitization

### DIFF
--- a/src/PhpInfo.php
+++ b/src/PhpInfo.php
@@ -28,6 +28,7 @@ class PhpInfo
 		}
 		$sanitize = $this->sanitize + $sanitize;
 		foreach ($sanitize as $search => $replace) {
+			$search = (string)$search;
 			$replacements[$search] = $replace;
 			$replacements[urlencode($search)] = $replace;
 		}

--- a/tests/PhpInfoTest.phpt
+++ b/tests/PhpInfoTest.phpt
@@ -76,6 +76,23 @@ class PhpInfoTest extends TestCase
 		Assert::contains(self::WALDO_1338, $html);
 	}
 
+
+	public function testGetHtmlNumericSessionId(): void
+	{
+		$sessionId = '31337';
+		$_COOKIE['PHPSESSID'] = $sessionId;
+
+		// Set a new session id
+		session_destroy();
+		session_set_save_handler(new TestSessionHandler($sessionId));
+		session_start();
+
+		Assert::noError(function () use ($sessionId, &$html): void {
+			$html = (new PhpInfo())->getHtml();
+		});
+		Assert::notContains($sessionId, $html);
+	}
+
 }
 
 (new PhpInfoTest())->run();


### PR DESCRIPTION
However improbable they are in reality, in tests though...

Follow-up to #8