### PR TITLE
Can configure the sanitizer as a standalone object to sanitize arbitrary strings too

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,18 @@ If found, the string in `$sanitize` will be replaced with the string `$with`, if
 
 Some of the values in `phpinfo()` output are printed URL-encoded, so the `$sanitize` value will also be searched URL-encoded automatically.
 This means that both `foo,bar` and `foo%2Cbar` would be replaced.
+
+## Sanitizing arbitrary strings
+If you have your `phpinfo()` output (or anything really) in a string, you can use the sanitizer standalone, for example:
+```php
+$sanitizer = new SensitiveValueSanitizer();
+$string = $sanitizer->addSanitization('🍍', '🍌')->sanitize('🍍🍕');
+```
+
+The sanitizer will sanitize session id automatically, you can (but shouldn't) disable it with `doNotSanitizeSessionId()`.
+
+You can then pass the configured sanitizer to `PhpInfo` class which will then use your configuration for sanitizing the `phpinfo()` output too:
+```php
+$phpInfo = new PhpInfo($sanitizer);
+$html = $phpInfo->getHtml();
+```

--- a/src/SensitiveValueSanitizer.php
+++ b/src/SensitiveValueSanitizer.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PhpInfo;
+
+class SensitiveValueSanitizer
+{
+
+	private bool $sanitizeSessionId = true;
+
+	private string $sanitizeWith = '[***]';
+
+	/** @var array<string, string> */
+	private array $sanitize = [];
+
+
+	public function sanitize(string $info): string
+	{
+		$sanitize = [];
+		if ($this->sanitizeSessionId && $this->getSessionId() !== null) {
+			$sanitize[$this->getSessionId()] = $this->sanitizeWith;
+			$sanitize[urlencode($this->getSessionId())] = $this->sanitizeWith;
+		}
+		return strtr($info, $this->sanitize + $sanitize);
+	}
+
+
+	private function getSessionId(): ?string
+	{
+		return session_id() ?: null;
+	}
+
+
+	/**
+	 * WARNING: Not recommended, disabling session id sanitization may allow
+	 * session stealing attacks that read the cookie from the output of phpinfo().
+	 */
+	public function doNotSanitizeSessionId(): self
+	{
+		$this->sanitizeSessionId = false;
+		return $this;
+	}
+
+
+	public function addSanitization(string $sanitize, ?string $with = null): self
+	{
+		$this->sanitize[$sanitize] = $this->sanitize[urlencode($sanitize)] = $with ?? $this->sanitizeWith;
+		return $this;
+	}
+
+}

--- a/tests/PhpInfoTest.phpt
+++ b/tests/PhpInfoTest.phpt
@@ -79,20 +79,14 @@ class PhpInfoTest extends TestCase
 	}
 
 
-	public function testGetHtmlNumericSessionId(): void
+	public function testGetHtmlSessionIdSanitizationCustomSanitizer(): void
 	{
-		$sessionId = '31337';
-		$_COOKIE['PHPSESSID'] = $sessionId;
-
-		// Set a new session id
-		session_destroy();
-		session_set_save_handler(new TestSessionHandler($sessionId));
-		session_start();
-
-		Assert::noError(function () use ($sessionId, &$html): void {
-			$html = (new PhpInfo())->getHtml();
-		});
-		Assert::notContains($sessionId, $html);
+		$sanitizer = new SensitiveValueSanitizer();
+		$sanitizer->addSanitization(self::SESSION_ID, '🍕');
+		$html = (new PhpInfo($sanitizer))->getHtml();
+		Assert::notContains(self::SESSION_ID, $html);
+		Assert::notContains(urlencode(self::SESSION_ID), $html);
+		Assert::contains('🍕', $html);
 	}
 
 }

--- a/tests/SensitiveValueSanitizerTest.phpt
+++ b/tests/SensitiveValueSanitizerTest.phpt
@@ -1,0 +1,95 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PhpInfo;
+
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/bootstrap.php';
+
+class SensitiveValueSanitizerTest extends TestCase
+{
+
+	private const SESSION_ID = 'foobar,baz';
+
+	private string $string;
+
+
+	public function __construct()
+	{
+		$this->string = sprintf('waldo %s fred %s quux', self::SESSION_ID, urlencode(self::SESSION_ID));
+	}
+
+
+	protected function setUp(): void
+	{
+		session_set_save_handler(new TestSessionHandler(self::SESSION_ID));
+		session_start();
+	}
+
+
+	protected function tearDown(): void
+	{
+		session_destroy();
+	}
+
+
+	public function testSanitize(): void
+	{
+		$string = (new SensitiveValueSanitizer())->sanitize($this->string);
+		Assert::contains('waldo', $string);
+		Assert::notContains(self::SESSION_ID, $string);
+		Assert::notContains(urlencode(self::SESSION_ID), $string);
+		Assert::contains('[***]', $string);
+	}
+
+
+	public function testSanitizeSessionIdCustomReplacement(): void
+	{
+		$sanitizer = new SensitiveValueSanitizer();
+		$sanitizer->addSanitization(self::SESSION_ID, 'yeah, sure');
+		$string = $sanitizer->sanitize($this->string);
+		Assert::contains('waldo', $string);
+		Assert::notContains(self::SESSION_ID, $string);
+		Assert::notContains(urlencode(self::SESSION_ID), $string);
+		Assert::contains('yeah, sure', $string);
+	}
+
+
+	public function testSanitizeDoNotSanitizeSessionIdButWhy(): void
+	{
+		$string = (new SensitiveValueSanitizer())->doNotSanitizeSessionId()->sanitize($this->string);
+		Assert::contains('waldo', $string);
+		Assert::contains(self::SESSION_ID, $string);
+		Assert::contains(urlencode(self::SESSION_ID), $string);
+		Assert::notContains('[***]', $string);
+	}
+
+
+	public function testSanitizeAddSanitization(): void
+	{
+		$string = (new SensitiveValueSanitizer())->addSanitization('setec', '🍌')->sanitize('setec astronomy');
+		Assert::notContains('setec', $string);
+		Assert::contains('🍌', $string);
+	}
+
+
+	public function testGetHtmlNumericSessionId(): void
+	{
+		$sessionId = '31337';
+
+		// Set a new session id
+		session_destroy();
+		session_set_save_handler(new TestSessionHandler($sessionId));
+		session_start();
+
+		Assert::noError(function () use ($sessionId, &$html): void {
+			$html = (new SensitiveValueSanitizer())->sanitize("31336 + 1 = {$sessionId}");
+		});
+		Assert::notContains($sessionId, $html);
+	}
+
+}
+
+(new SensitiveValueSanitizerTest())->run();


### PR DESCRIPTION
For example:

```php
$sanitizer = new SensitiveValueSanitizer();
$sanitizer->addSanitization('🍍', '🍌');
$string = $sanitizer->sanitize('🍍🍕');

// [...]

$phpInfo = new PhpInfo($sanitizer);
$html = $phpInfo->getHtml();
```