### PR TITLE
Read `$_COOKIE[session_name()]` directly to find session id if session is not active

### DIFF
--- a/src/SensitiveValueSanitizer.php
+++ b/src/SensitiveValueSanitizer.php
@@ -27,7 +27,13 @@ class SensitiveValueSanitizer
 
 	private function getSessionId(): ?string
 	{
-		return session_id() ?: null;
+		$sessionId = session_id();
+		if ($sessionId) {
+			return $sessionId;
+		} else {
+			$sessionId = $_COOKIE[session_name()] ?? null;
+			return is_string($sessionId) ? $sessionId : null;
+		}
 	}
 
 

--- a/tests/SensitiveValueSanitizerNoSessionTest.phpt
+++ b/tests/SensitiveValueSanitizerNoSessionTest.phpt
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PhpInfo;
+
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/bootstrap.php';
+
+class SensitiveValueSanitizerNoSessionTest extends TestCase
+{
+
+	private const SESSION_ID = 'foobar,baz';
+
+
+	public function testSanitizeSessionNotStarted(): void
+	{
+		$_COOKIE[session_name()] = self::SESSION_ID;
+		$string = (new SensitiveValueSanitizer())->sanitize(sprintf('waldo %s fred', self::SESSION_ID));
+		Assert::contains('waldo', $string);
+		Assert::notContains(self::SESSION_ID, $string);
+		Assert::notContains(urlencode(self::SESSION_ID), $string);
+		Assert::contains('[***]', $string);
+	}
+
+}
+
+(new SensitiveValueSanitizerNoSessionTest())->run();


### PR DESCRIPTION
This will not cover all cases, for example session id will still not be found when the session name is configured in a service somewhere, but the README now covers the case as well by mentioning `addSanitization()`.