### PR TITLE
Add `getFullPageHtml()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ echo $phpInfo->getFullPageHtml();
 ```
 
 ## Sanitization
-By default, session id (as returned by `session_id()` if session is started, or as stored in `$_COOKIE[session_name()]` if not) will be sanitized and replaced by `[***]` in the output.
+By default, session id will be automatically determined and replaced by `[***]` in the output.
 This is to prevent some session hijacking attacks that would read the session id from the cookie value reflected in the `phpinfo()` output
 (see my [blog post](https://www.michalspacek.com/stealing-session-ids-with-phpinfo-and-how-to-stop-it) describing the attack, `HttpOnly` bypasses, and the solution).
 You can disable the sanitization by calling `doNotSanitizeSessionId()` but it's totally not recommended. Do not disable that. Please.
@@ -45,29 +45,29 @@ If found, the string in `$sanitize` will be replaced with the string `$with`, if
 Some of the values in `phpinfo()` output are printed URL-encoded, so the `$sanitize` value will also be searched URL-encoded automatically.
 This means that both `foo,bar` and `foo%2Cbar` would be replaced.
 
-## Sanitizing arbitrary strings
-If you have your `phpinfo()` output (or anything really) in a string, you can use the sanitizer standalone, for example:
-```php
-$sanitizer = new \Spaze\PhpInfo\SensitiveValueSanitizer();
-$string = $sanitizer->addSanitization('🍍', '🍌')->sanitize('🍍🍕');
-```
-
 The sanitizer will try to determine the session id and sanitize it automatically, you can (but shouldn't) disable it with `doNotSanitizeSessionId()`.
 
-The following values will be automatically used as the session id:
+The following values will be used when determining the session id:
 1. `session_id()` output if not `false`
 2. `$_COOKIE[session_name()]` if it's a string
 
 However, it is not recommended to rely solely on the automated way, because for example you may set the session name somewhere in a custom service,
 and it may not be available for the sanitizer to use. I'd rather suggest you configure the sanitization manually:
 ```php
-$sanitizer->addSanitization($this->sessionHandler->getId(), '[***]'); // where $this->sessionHandler is your custom service for example
+$phpInfo->addSanitization($this->sessionHandler->getId(), '[***]'); // where $this->sessionHandler is your custom service for example
 ```
 or
 ```php
-$sanitizer->addSanitization($_COOKIE['MYSESSID'], '[***]'); // where MYSESSID is your session name
+$phpInfo->addSanitization($_COOKIE['MYSESSID'], '[***]'); // where MYSESSID is your session name
 ```
 or something like that.
+
+## Sanitizing arbitrary strings
+If you have your `phpinfo()` output (or anything really) in a string, you can use the sanitizer standalone, for example:
+```php
+$sanitizer = new \Spaze\PhpInfo\SensitiveValueSanitizer();
+$string = $sanitizer->addSanitization('🍍', '🍌')->sanitize('🍍🍕');
+```
 
 You can then pass the configured sanitizer to `PhpInfo` class which will then use your configuration for sanitizing the `phpinfo()` output too:
 ```php

--- a/README.md
+++ b/README.md
@@ -8,13 +8,26 @@ $phpInfo = new \Spaze\PhpInfo\PhpInfo();
 $html = $phpInfo->getHtml();
 ```
 
-`$html` will contain `phpinfo()` output, wrapped in `<div id="phpinfo">` & `</div>`.
+## `getHtml()`
+The `getHtml()` method returns the `phpinfo()` output, without the HTML `head` and `body` elements, wrapped in `<div id="phpinfo">` & `</div>`.
 
 All inline CSS will be "externalized" to CSS classes, you can load `assets/info.css` to get the colors back.
 
 An example usage with Nette Framework (can be used with other frameworks or standalone, too):
 ```php
 $this->template->phpinfo = Html::el()->setHtml($this->phpInfo->getHtml());
+```
+
+Please note that this will also remove the HTML `head` element which contains `meta name="ROBOTS"` tag preventing search engines and other bots indexing the `phpinfo()` output.
+You have to add it back somehow, for example by rendering the `getHtml()` output in your own layout which includes the `head` element with the `meta name="ROBOTS"` tag.
+In general, `phpinfo()` output should be accessible only for authenticated users.
+
+## `getFullPageHtml()`
+Sometimes, you may want to display the classic `phpinfo()` output, with the original HTML `head` and `body` elements, `meta name="ROBOTS"` tag, inline styles etc.,
+but still with the sensitive info sanitized (see below). In that case, you may use `getFullPageHtml()`:
+```php
+$phpInfo = new \Spaze\PhpInfo\PhpInfo();
+echo $phpInfo->getFullPageHtml();
 ```
 
 ## Sanitization

--- a/src/PhpInfo.php
+++ b/src/PhpInfo.php
@@ -28,6 +28,16 @@ class PhpInfo
 	}
 
 
+	public function getFullPageHtml(): string
+	{
+		$error = 'Cannot get phpinfo() output';
+		ob_start();
+		phpinfo();
+		$info = ob_get_clean() ?: $error;
+		return $this->sanitizer->sanitize($info);
+	}
+
+
 	/**
 	 * WARNING: Not recommended, disabling session id sanitization may allow
 	 * session stealing attacks that read the cookie from the output of phpinfo().

--- a/tests/PhpInfoTest.phpt
+++ b/tests/PhpInfoTest.phpt
@@ -43,6 +43,16 @@ class PhpInfoTest extends TestCase
 	}
 
 
+	public function testGetFullPageHtml(): void
+	{
+		$html = (new PhpInfo())->getFullPageHtml();
+		Assert::notContains('<div id="phpinfo">', $html);
+		Assert::contains('disable_functions', $html);
+		Assert::notContains('class="color-', $html);
+		Assert::contains('style="color: #', $html);
+	}
+
+
 	public function testGetHtmlSessionIdSanitization(): void
 	{
 		$html = (new PhpInfo())->getHtml();


### PR DESCRIPTION
`getFullPageHtml()` doesn't remove HEAD & BODY and preserve inline styles while still sanitizing what it's supposed to be sanitized.