### PR TITLE
Drop PHP 7.4 support

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
           - "8.0"
           - "8.1"
           - "8.2"

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"require": {
-		"php": "^7.4 || ^8.0"
+		"php": "^8.0"
 	},
 	"require-dev": {
 		"php-parallel-lint/php-parallel-lint": "^1.4",


### PR DESCRIPTION
Because the nette/tester version that supports PHP 8.5 doesn't support 7.4, and test with `--prefer-lowest` would fail with anything else than nette/tester with 8.5 support. Tests on 8.5 added in #19.