### PR TITLE
Run tests on PHP 8.5 too

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -15,6 +15,7 @@ jobs:
           - "8.2"
           - "8.3"
           - "8.4"
+          - "8.5"
         update-options:
             - ""
             - "--prefer-lowest"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"php-parallel-lint/php-console-highlighter": "^1.0",
 		"phpstan/phpstan": "^2.1",
 		"spaze/coding-standard": "^1.8",
-		"nette/tester": "^2.4"
+		"nette/tester": "^2.5.7"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
Also require Tester with PHP 8.5 support, otherwise `--prefer-lowest` tests fail on 8.5.