### PR TITLE
Minor cleanup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "spaze/phpinfo",
-	"description": "Extract phpinfo() into a variable and move CSS to external file.",
+	"description": "Extract phpinfo() output into a variable, sanitize sensitive values, and move inline styles to external CSS.",
 	"keywords": ["PHP","phpinfo"],
 	"license": "MIT",
 	"authors": [

--- a/src/PhpInfo.php
+++ b/src/PhpInfo.php
@@ -66,6 +66,9 @@ final class PhpInfo
 	}
 
 
+	/**
+	 * @param non-empty-string $sanitize
+	 */
 	public function addSanitization(string $sanitize, ?string $with = null): self
 	{
 		$this->sanitizer->addSanitization($sanitize, $with);

--- a/src/SensitiveValueSanitizer.php
+++ b/src/SensitiveValueSanitizer.php
@@ -64,6 +64,9 @@ final class SensitiveValueSanitizer
 	}
 
 
+	/**
+	 * @param non-empty-string $sanitize
+	 */
 	public function addSanitization(string $sanitize, ?string $with = null): self
 	{
 		$this->sanitize[$sanitize] = $this->sanitize[urlencode($sanitize)] = $with ?? $this->sanitizeWith;

--- a/src/SensitiveValueSanitizer.php
+++ b/src/SensitiveValueSanitizer.php
@@ -49,7 +49,7 @@ final class SensitiveValueSanitizer
 		} else {
 			$sessionId = $_COOKIE[$sessionName] ?? null;
 		}
-		return is_string($sessionId) ? $sessionId : null;
+		return is_string($sessionId) && $sessionId !== '' ? $sessionId : null;
 	}
 
 

--- a/src/SensitiveValueSanitizer.php
+++ b/src/SensitiveValueSanitizer.php
@@ -26,9 +26,12 @@ final class SensitiveValueSanitizer
 	public function sanitize(string $info): string
 	{
 		$sanitize = [];
-		if ($this->sanitizeSessionId && $this->getSessionId() !== null) {
-			$sanitize[$this->getSessionId()] = $this->sanitizeWith;
-			$sanitize[urlencode($this->getSessionId())] = $this->sanitizeWith;
+		if ($this->sanitizeSessionId) {
+			$sessionId = $this->getSessionId();
+			if ($sessionId !== null) {
+				$sanitize[$sessionId] = $this->sanitizeWith;
+				$sanitize[urlencode($sessionId)] = $this->sanitizeWith;
+			}
 		}
 		return strtr($info, $this->sanitize + $sanitize);
 	}

--- a/tests/PhpInfoTest.phpt
+++ b/tests/PhpInfoTest.phpt
@@ -23,11 +23,7 @@ class PhpInfoTest extends TestCase
 	protected function setUp(): void
 	{
 		$_SERVER['HTTP_WALDO_FRED'] = self::WALDO_1337;
-		$_SERVER['HTTP_COOKIE'] = 'PHPSESSID=' . urlencode(self::SESSION_ID);
-		$_COOKIE['PHPSESSID'] = self::SESSION_ID;
-
-		session_set_save_handler(new TestSessionHandler(self::SESSION_ID));
-		session_start();
+		$this->sessionStart(self::SESSION_ID);
 	}
 
 
@@ -133,6 +129,25 @@ class PhpInfoTest extends TestCase
 		Assert::notContains(self::SESSION_ID, $html);
 		Assert::notContains(urlencode(self::SESSION_ID), $html);
 		Assert::contains('🍕', $html);
+	}
+
+
+	public function testGetHtmlEmptySessionCookie(): void
+	{
+		session_destroy();
+		$this->sessionStart('');
+		Assert::noError(function (): void {
+			(new PhpInfo())->getHtml();
+		});
+	}
+
+
+	private function sessionStart(string $sessionId): void
+	{
+		$_SERVER['HTTP_COOKIE'] = 'PHPSESSID=' . urlencode($sessionId);
+		$_COOKIE['PHPSESSID'] = $sessionId;
+		session_set_save_handler(new TestSessionHandler($sessionId));
+		session_start();
 	}
 
 }


### PR DESCRIPTION
- Call `getSessionId()` just once
- Pass only non-empty string to `strtr()`, otherwise it throws a warning (reworked in #30)
- Update description in `composer.json`