### PR TITLE
Check empty sanitization string run-time

### DIFF
--- a/src/PhpInfo.php
+++ b/src/PhpInfo.php
@@ -66,9 +66,6 @@ final class PhpInfo
 	}
 
 
-	/**
-	 * @param non-empty-string $sanitize
-	 */
 	public function addSanitization(string $sanitize, ?string $with = null): self
 	{
 		$this->sanitizer->addSanitization($sanitize, $with);

--- a/src/SensitiveValueSanitizer.php
+++ b/src/SensitiveValueSanitizer.php
@@ -64,11 +64,11 @@ final class SensitiveValueSanitizer
 	}
 
 
-	/**
-	 * @param non-empty-string $sanitize
-	 */
 	public function addSanitization(string $sanitize, ?string $with = null): self
 	{
+		if ($sanitize === '') {
+			return $this;
+		}
 		$this->sanitize[$sanitize] = $this->sanitize[urlencode($sanitize)] = $with ?? $this->sanitizeWith;
 		return $this;
 	}

--- a/tests/SensitiveValueSanitizerTest.phpt
+++ b/tests/SensitiveValueSanitizerTest.phpt
@@ -143,6 +143,16 @@ class SensitiveValueSanitizerTest extends TestCase
 		Assert::notContains($sessionId, $html);
 	}
 
+
+	public function testAddSanitizationEmptyString(): void
+	{
+		Assert::noError(function () use (&$string): void {
+			$string = (new SensitiveValueSanitizer())->addSanitization('', '💫')->sanitize('foo');
+		});
+		Assert::same('foo', $string);
+		Assert::notContains('💫', $string);
+	}
+
 }
 
 (new SensitiveValueSanitizerTest())->run();


### PR DESCRIPTION
Annotating with PHPStan is fine, but requires some work to be done by the caller to not pass empty strings. This is more friendly.

Partially reverts some work done in #28